### PR TITLE
feat: Add built-in photo effects and refactor PhotoModeComposer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# React Fiber Photo Mode
+﻿# React Fiber Photo Mode
 
 [![Version](https://badgen.net/npm/v/fiber-photo-mode)](https://www.npmjs.com/package/fiber-photo-mode)
 
-PhotoMode / screenshot capture system for [React Three Fiber](https://github.com/pmndrs/react-three-fiber).
+PhotoMode / screenshot capture system with post-processing effects for [React Three Fiber](https://github.com/pmndrs/react-three-fiber).
 
 ⚠️ Warning: Early-stage, experimental – under active development. The API may change in future releases.
 
@@ -16,17 +16,20 @@ npm install fiber-photo-mode
 
 React Fiber Photo Mode makes it easy to take high-quality screenshots of your Three.js / React Three Fiber scenes, including post-processing effects and camera settings.
 
-While it’s technically possible to capture directly from the canvas, fiber-capture lets you:
+While it's technically possible to capture directly from the canvas, fiber-photo-mode lets you:
 
 - Take screenshots at custom resolutions independent of the canvas size
 - Override the canvas pixel ratio for better quality (e.g., if your canvas uses a low pixel ratio for performance, the screenshot can still be full-quality)
 - Capture scenes with post-processing effects, keeping the same visual fidelity as in the canvas
+- Apply photo effects (Bloom, Brightness/Contrast, Hue/Saturation, Vignette, Chromatic Aberration, Grain) to your captures
 
 ## Usage
 
-Insert `<PhotoMode />` into your `<Canvas>` and call a hook to capture screenshots anywhere in your app.
+### Basic Setup
 
-```js
+Insert `<PhotoMode />` into your `<Canvas>` and call a hook to capture screenshots anywhere in your app:
+
+```jsx
 import { Canvas } from "@react-three/fiber";
 import { PhotoMode } from "fiber-photo-mode";
 
@@ -36,45 +39,149 @@ import { PhotoMode } from "fiber-photo-mode";
 </Canvas>;
 ```
 
-Use the usePhotoMode hook to take a screenshot:
+### Taking Screenshots
 
-```js
-import { usePhotoMode } from "fiber-capture";
+Use the `usePhotoMode` hook to capture screenshots:
+
+```jsx
+import { usePhotoMode } from "fiber-photo-mode";
 
 const MyComponent = () => {
-  const { takeScreenshot } = usePhotoMode();
+  const { takeScreenshot, togglePhotoMode } = usePhotoMode();
 
   const handleClick = async () => {
-    const file = await takeScreenshot();
-    console.log("Screenshot ready:", file);
+    const dataUrl = await takeScreenshot();
+    console.log("Screenshot ready:", dataUrl);
   };
 
   return <button onClick={handleClick}>Take Screenshot</button>;
 };
 ```
 
-⚠️ Important: If you are using EffectComposer from @react-three/postprocessing for post-processing, replace it with `<PhotoModeComposer>` to ensure the screenshot captures all effects correctly.
+### Screenshot Options
 
-```js
-import { PhotoModeComposer } from "fiber-photo-mode";
+The `takeScreenshot` function accepts optional configuration:
 
-function Postprocessing() {
+```jsx
+const file = await takeScreenshot({
+  width: 1920, // Custom width (default: canvas width)
+  height: 1080, // Custom height (default: canvas height)
+  format: "png", // 'jpeg' | 'png' | 'webp' | 'avif' (default: 'png')
+  quality: 0.95, // Compression quality 0-1 (default: 0.8)
+  toFile: true, // Return as File instead of DataURL
+});
+```
+
+### Using Post-Processing Effects
+
+`<PhotoMode />` includes an integrated `EffectComposer` - any post-processing effects you want to capture must be placed as children of `<PhotoMode>`:
+
+```jsx
+import { Canvas } from "@react-three/fiber";
+import { PhotoMode } from "fiber-photo-mode";
+import { BrightnessContrast, ToneMapping } from "@react-three/postprocessing";
+
+<Canvas>
+  <PhotoMode>
+    <BrightnessContrast brightness={0} contrast={0.25} />
+    <ToneMapping />
+  </PhotoMode>
+  {/* Your scene */}
+</Canvas>;
+```
+
+**Important:** These effects passed as children to `<PhotoMode>` will be visible in the canvas at all times, not just in screenshots. If you want effects visible only in photo mode, use the `usePhotoModeEffects` hook instead.
+
+### Built-in Photo Effects
+
+The library includes built-in photo effects that are added to the `EffectComposer` and can be toggled and controlled independently. By default, all effects are enabled **except Bloom** (which is experimental and may cause visual artifacts).
+
+Use the `enabledEffects` prop to configure which built-in effects are added to the effect composer. The `enabledEffects` prop is **optional** - you only need to specify the effects you want to override from the defaults:
+
+```jsx
+<PhotoMode
+  enabledEffects={{
+    bloom: true,  // Enable Bloom (disabled by default)
+  }}
+  {/* Your effects from react-postprocessing */}
+</PhotoMode>
+```
+
+**Important distinction:** The `enabledEffects` prop determines which effects are **added to the `EffectComposer`**, not whether they are visible. By default, when effects are added, they are inactive (with zero intensity/values).
+
+To actually see these effects in your canvas and screenshots, you must:
+
+1. **Enable photo mode** using the hook:
+
+```jsx
+const { togglePhotoMode } = usePhotoMode();
+togglePhotoMode(); // Enables photo mode
+```
+
+2. **Set effect values** using the effects hook:
+
+```jsx
+const { setEffect } = usePhotoModeEffects();
+setEffect("bloom", 2.5);
+setEffect("brightness", 0.3);
+```
+
+### Controlling Photo Effects
+
+Use the `usePhotoModeEffects` hook to read current effect values and control them:
+
+```jsx
+import { usePhotoMode, usePhotoModeEffects } from "fiber-photo-mode";
+
+export function PhotoModeUI() {
+  const { brightness, setEffect } = usePhotoModeEffects();
+
+  const { photoModeOn } = usePhotoMode();
+
+  if (!photoModeOn) return null;
+
   return (
-    <PhotoModeComposer>
-      <BrightnessContrast brightness={0} contrast={0.25} />
-      <ToneMapping />
-    </PhotoModeComposer>
+    <>
+      <input
+        type="range"
+        value={brightness}
+        onChange={(e) => setEffect("brightness", parseFloat(e.target.value))}
+        min={-1}
+        max={1}
+        step={0.01}
+        className="w-full"
+      />
   );
 }
 ```
 
+## Available Photo Effects
+
+- **Hue/Saturation** - Adjust color tone and saturation (enabled by default)
+- **Brightness/Contrast** - Modify exposure and contrast (enabled by default)
+- **Vignette** - Darken edges for a focused look (enabled by default)
+- **Chromatic Aberration** - Add RGB color shift for stylized effect (enabled by default)
+- **Grain** - Add film grain texture (enabled by default)
+- **Bloom** - Add glow to bright areas (disabled by default - experimental)
+
+## Effect Behavior Summary
+
+| Aspect                  | Built-in Photo Effects                   | Custom Effects (as children)        |
+| ----------------------- | ---------------------------------------- | ----------------------------------- |
+| Added via               | `enabledEffects` prop                    | `<PhotoMode>{children}</PhotoMode>` |
+| Visibility              | Only visible in photo mode (when active) | Always visible on canvas            |
+| Captured in screenshots | Yes                                      | Yes                                 |
+| Togglable               | Yes, via `togglePhotoMode()`             | Always active                       |
+| Configurable            | Yes, via `usePhotoModeEffects()`         | Configured directly on component    |
+
 ## Features
 
 - 1:1 screenshot of the canvas with accurate camera & viewport
-- Supports FBO and post-processing via PhotoModeComposer
+- Built-in photo effects integrated into `<PhotoMode>`
 - Capture at custom resolutions, independent of canvas size or pixel ratio
-- Easy-to-use hook for calling screenshots from anywhere in your app
-- Compatible with post-processing pipelines when using `<PhotoModeComposer>`
+- Easy-to-use hooks for calling screenshots and managing effects from anywhere in your app
+- Support for custom post-processing effects as children
+- Automatic effect pass management
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fiber-photo-mode",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": "Łukasz Kwas (https://github.com/kvvasuu)",
   "description": "A React Three Fiber component to add photo mode functionality to your 3D scenes.",
   "license": "MIT",

--- a/src/engine/PhotoMode.tsx
+++ b/src/engine/PhotoMode.tsx
@@ -1,21 +1,29 @@
 import { useThree } from "@react-three/fiber";
-import { useLayoutEffect } from "react";
+import { useEffect, useLayoutEffect } from "react";
+import { usePhotoModeEffectsStore } from "../store/photoModeEffectsStore";
 import { usePhotoModeStore } from "../store/photoModeStore";
+import { EffectName } from "../types";
 import { takeScreenshot } from "../utils/functions";
+import { PhotoModeComposer } from "./PhotoModeComposer";
 
 /**
  * PhotoMode component - Initialize in your Three.js canvas
  * Registers screenshot function and rendering context
  * Must be placed inside <Canvas> component
  */
-export function PhotoMode() {
-  const { gl, scene, camera } = useThree();
-  const composer = usePhotoModeStore((s) => s.composer);
 
-  const setRenderer = usePhotoModeStore((s) => s.setRenderer);
-  const setScene = usePhotoModeStore((s) => s.setScene);
-  const setCamera = usePhotoModeStore((s) => s.setCamera);
-  const setTakeScreenshot = usePhotoModeStore((s) => s.setTakeScreenshot);
+interface PhotoModeProps {
+  children?: React.ReactNode;
+  enabledEffects?: Partial<Record<EffectName, boolean>>;
+}
+export function PhotoMode({ children, enabledEffects }: PhotoModeProps) {
+  const { gl, scene, camera } = useThree();
+  const composer = usePhotoModeStore((state) => state.composer);
+
+  const setRenderer = usePhotoModeStore((state) => state.setRenderer);
+  const setScene = usePhotoModeStore((state) => state.setScene);
+  const setCamera = usePhotoModeStore((state) => state.setCamera);
+  const setTakeScreenshot = usePhotoModeStore((state) => state.setTakeScreenshot);
 
   useLayoutEffect(() => {
     // Register rendering context
@@ -27,5 +35,12 @@ export function PhotoMode() {
     setTakeScreenshot(takeScreenshot(gl, scene, camera, composer || undefined));
   }, [gl, scene, camera, composer, setRenderer, setScene, setCamera, setTakeScreenshot]);
 
-  return null;
+  useEffect(() => {
+    if (enabledEffects)
+      usePhotoModeEffectsStore.setState((state) => {
+        return { enabledEffects: { ...state.enabledEffects, ...enabledEffects } };
+      });
+  }, [enabledEffects]);
+
+  return <PhotoModeComposer>{children}</PhotoModeComposer>;
 }

--- a/src/engine/PhotoModeComposer.tsx
+++ b/src/engine/PhotoModeComposer.tsx
@@ -1,43 +1,48 @@
+import type { EffectComposerProps } from "@react-three/postprocessing";
+import { EffectComposer } from "@react-three/postprocessing";
+import { EffectComposer as EffectComposerImpl } from "postprocessing";
+import { forwardRef } from "react";
+import { usePhotoModeStore } from "../store/photoModeStore";
+import { PhotoModeEffects } from "./PhotoModeEffects";
+
+/**
+ * Props for PhotoModeComposer
+ */
+type PhotoModeComposerProps = Omit<EffectComposerProps, "children"> & {
+  children?: React.ReactNode;
+  enableBloom?: boolean;
+};
+
 /**
  * PhotoModeComposer Component
  * Wraps EffectComposer to register it with PhotoMode store
  * Enables post-processing effects in screenshot capture
  */
+export const PhotoModeComposer = forwardRef<EffectComposerImpl, PhotoModeComposerProps>(
+  ({ children, ...props }, ref) => {
+    const setComposer = usePhotoModeStore((state) => state.setComposer);
 
-import type { EffectComposerProps } from '@react-three/postprocessing';
-import { EffectComposer } from '@react-three/postprocessing';
-import { EffectComposer as EffectComposerImpl } from 'postprocessing';
-import { forwardRef, ReactNode } from 'react';
-import { usePhotoModeStore } from '../store/photoModeStore';
+    return (
+      <EffectComposer
+        {...props}
+        ref={(c: EffectComposerImpl | null) => {
+          // Register composer in store
+          setComposer(c);
+          // Pass ref to parent
+          if (typeof ref === "function") ref(c);
+          else if (ref) ref.current = c;
+        }}
+      >
+        <>
+          {/* User Effects first */}
+          {children}
 
-/**
- * Props for PhotoModeComposer
- */
-type PhotoModeComposerProps = EffectComposerProps & {
-	children: ReactNode;
-};
+          {/* Photo Mode Effects last */}
+          <PhotoModeEffects />
+        </>
+      </EffectComposer>
+    );
+  },
+);
 
-/**
- * PhotoModeComposer - Wraps EffectComposer for PhotoMode integration
- * Automatically registers composer for screenshot post-processing
- */
-export const PhotoModeComposer = forwardRef<EffectComposerImpl, PhotoModeComposerProps>(({ children, ...props }, ref) => {
-	const setComposer = usePhotoModeStore((state) => state.setComposer);
-
-	return (
-		<EffectComposer
-			{...props}
-			ref={(c: EffectComposerImpl | null) => {
-				// Register composer in store
-				setComposer(c);
-				// Pass ref to parent
-				if (typeof ref === 'function') ref(c);
-				else if (ref) ref.current = c;
-			}}
-		>
-			{children}
-		</EffectComposer>
-	);
-});
-
-PhotoModeComposer.displayName = 'PhotoModeComposer';
+PhotoModeComposer.displayName = "PhotoModeComposer";

--- a/src/engine/PhotoModeEffects.tsx
+++ b/src/engine/PhotoModeEffects.tsx
@@ -1,0 +1,91 @@
+import {
+  BloomEffect,
+  BrightnessContrastEffect,
+  ChromaticAberrationEffect,
+  EffectPass,
+  HueSaturationEffect,
+  NoiseEffect,
+  VignetteEffect,
+} from "postprocessing";
+import { useEffect, useRef } from "react";
+import { Vector2 } from "three";
+import { usePhotoModeEffectsStore } from "../store/photoModeEffectsStore";
+import { usePhotoModeStore } from "../store/photoModeStore";
+import { Bloom } from "./effects/Bloom";
+import { BrightnessContrast } from "./effects/BrightnessContrast";
+import { ChromaticAberration } from "./effects/ChromaticAberration";
+import { Grain } from "./effects/Grain";
+import { HueSaturation } from "./effects/HueSaturation";
+import { Vignette } from "./effects/Vignette";
+
+export function PhotoModeEffects() {
+  const composer = usePhotoModeStore((state) => state.composer);
+  const camera = usePhotoModeStore((state) => state.camera);
+  const enabledEffects = usePhotoModeEffectsStore((state) => state.enabledEffects);
+
+  const effectsRef = useRef({
+    hueSaturation: new HueSaturationEffect({ hue: 0, saturation: 0 }),
+    brightnessContrast: new BrightnessContrastEffect({ brightness: 0, contrast: 0 }),
+    chromaticAberration: new ChromaticAberrationEffect({
+      offset: new Vector2(0, 0),
+      radialModulation: false,
+      modulationOffset: 0,
+    }),
+    bloom: new BloomEffect({
+      intensity: 0,
+    }),
+    vignette: new VignetteEffect({ offset: 0, darkness: 0 }),
+    grain: new NoiseEffect({ premultiply: true }),
+  });
+
+  useEffect(() => {
+    if (!composer || !camera) return;
+
+    // Effects order: - from postprocessing docs and common practices, this should be not changed to prevent issues.
+    // Hue/Saturation
+    // Brightness/Contrast
+    // SMAA
+    // SSR (NYI)
+    // SSAO
+    // DoF
+    // Motion Blur (NYI)
+    // Chromatic Aberration
+    // Bloom
+    // God Rays
+    // Vignette
+    // Tone Mapping
+    // LUT / Color Grading
+    // Noise / Film Grain
+    // PixelationEffect
+
+    const effects = [
+      effectsRef.current.hueSaturation,
+      effectsRef.current.brightnessContrast,
+      effectsRef.current.chromaticAberration,
+      ...(enabledEffects.bloom ? [effectsRef.current.bloom] : []),
+      effectsRef.current.vignette,
+      effectsRef.current.grain,
+    ];
+
+    const effectPass = new EffectPass(camera, ...effects);
+
+    effectPass.name = "PhotoModeEffectsPass";
+
+    composer.addPass(effectPass);
+
+    return () => effectPass.dispose();
+  }, [composer, camera, enabledEffects]);
+
+  if (!composer || !camera) return null;
+
+  return (
+    <>
+      {enabledEffects.hueSaturation && <HueSaturation effect={effectsRef.current.hueSaturation} />}
+      {enabledEffects.brightnessContrast && <BrightnessContrast effect={effectsRef.current.brightnessContrast} />}
+      {enabledEffects.vignette && <Vignette effect={effectsRef.current.vignette} />}
+      {enabledEffects.chromaticAberration && <ChromaticAberration effect={effectsRef.current.chromaticAberration} />}
+      {enabledEffects.bloom && <Bloom effect={effectsRef.current.bloom} />}
+      {enabledEffects.grain && <Grain effect={effectsRef.current.grain} />}
+    </>
+  );
+}

--- a/src/engine/effects/Bloom.tsx
+++ b/src/engine/effects/Bloom.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from "react";
+
+import { BloomEffect } from "postprocessing";
+import { usePhotoModeEffectsStore } from "../../store/photoModeEffectsStore";
+import { usePhotoModeStore } from "../../store/photoModeStore";
+import { mapEffectValue } from "../../utils/functions";
+
+export function Bloom({ effect }: { effect: BloomEffect }) {
+  const bloom = usePhotoModeEffectsStore((state) => state.bloom);
+
+  const photoModeOn = usePhotoModeStore((state) => state.photoModeOn);
+
+  useEffect(() => {
+    if (!effect) return;
+
+    effect.intensity = photoModeOn ? mapEffectValue(bloom, "bloom") : 0;
+  }, [effect, bloom, photoModeOn]);
+
+  return null;
+}

--- a/src/engine/effects/BrightnessContrast.tsx
+++ b/src/engine/effects/BrightnessContrast.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+
+import { BrightnessContrastEffect } from "postprocessing";
+import { usePhotoModeEffectsStore } from "../../store/photoModeEffectsStore";
+import { usePhotoModeStore } from "../../store/photoModeStore";
+import { mapEffectValue } from "../../utils/functions";
+
+export function BrightnessContrast({ effect }: { effect: BrightnessContrastEffect }) {
+  const brightness = usePhotoModeEffectsStore((state) => state.brightness);
+  const contrast = usePhotoModeEffectsStore((state) => state.contrast);
+
+  const photoModeOn = usePhotoModeStore((state) => state.photoModeOn);
+
+  useEffect(() => {
+    if (!effect) return;
+
+    effect.brightness = photoModeOn ? mapEffectValue(brightness, "brightness") : 0;
+    effect.contrast = photoModeOn ? mapEffectValue(contrast, "contrast") : 0;
+  }, [effect, brightness, contrast, photoModeOn]);
+
+  return null;
+}

--- a/src/engine/effects/ChromaticAberration.tsx
+++ b/src/engine/effects/ChromaticAberration.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+
+import { ChromaticAberrationEffect } from "postprocessing";
+import { usePhotoModeEffectsStore } from "../../store/photoModeEffectsStore";
+import { usePhotoModeStore } from "../../store/photoModeStore";
+import { mapEffectValue } from "../../utils/functions";
+
+export function ChromaticAberration({ effect }: { effect: ChromaticAberrationEffect }) {
+  const chromaticAberration = usePhotoModeEffectsStore((state) => state.chromaticAberration);
+
+  const photoModeOn = usePhotoModeStore((state) => state.photoModeOn);
+
+  useEffect(() => {
+    if (!effect) return;
+
+    const chromaticAberrationValue = mapEffectValue(chromaticAberration, "chromaticAberration");
+
+    effect.offset.x = photoModeOn ? chromaticAberrationValue : 0;
+    effect.offset.y = photoModeOn ? chromaticAberrationValue : 0;
+  }, [effect, chromaticAberration, photoModeOn]);
+
+  return null;
+}

--- a/src/engine/effects/Grain.tsx
+++ b/src/engine/effects/Grain.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+
+import { NoiseEffect } from "postprocessing";
+import { usePhotoModeEffectsStore } from "../../store/photoModeEffectsStore";
+import { usePhotoModeStore } from "../../store/photoModeStore";
+import { mapEffectValue } from "../../utils/functions";
+
+export function Grain({ effect }: { effect: NoiseEffect }) {
+  const grain = usePhotoModeEffectsStore((state) => state.grain);
+
+  const photoModeOn = usePhotoModeStore((state) => state.photoModeOn);
+
+  useEffect(() => {
+    if (!effect) return;
+
+    effect.blendMode.opacity.value = photoModeOn ? mapEffectValue(grain, "grain") : 0;
+  }, [effect, grain, photoModeOn]);
+  return null;
+}

--- a/src/engine/effects/HueSaturation.tsx
+++ b/src/engine/effects/HueSaturation.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+
+import { HueSaturationEffect } from "postprocessing";
+import { usePhotoModeEffectsStore } from "../../store/photoModeEffectsStore";
+import { usePhotoModeStore } from "../../store/photoModeStore";
+import { mapEffectValue } from "../../utils/functions";
+
+export function HueSaturation({ effect }: { effect: HueSaturationEffect }) {
+  const hue = usePhotoModeEffectsStore((state) => state.hue);
+  const saturation = usePhotoModeEffectsStore((state) => state.saturation);
+
+  const photoModeOn = usePhotoModeStore((state) => state.photoModeOn);
+
+  useEffect(() => {
+    if (!effect) return;
+
+    effect.hue = photoModeOn ? mapEffectValue(hue, "hue") : 0;
+    effect.saturation = photoModeOn ? mapEffectValue(saturation, "saturation") : 0;
+  }, [effect, hue, saturation, photoModeOn]);
+
+  return null;
+}

--- a/src/engine/effects/Vignette.tsx
+++ b/src/engine/effects/Vignette.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+
+import { VignetteEffect } from "postprocessing";
+import { usePhotoModeEffectsStore } from "../../store/photoModeEffectsStore";
+import { usePhotoModeStore } from "../../store/photoModeStore";
+import { mapEffectValue } from "../../utils/functions";
+
+export function Vignette({ effect }: { effect: VignetteEffect }) {
+  const vignette = usePhotoModeEffectsStore((state) => state.vignette);
+
+  const photoModeOn = usePhotoModeStore((state) => state.photoModeOn);
+
+  useEffect(() => {
+    if (!effect) return;
+
+    const vignetteValue = mapEffectValue(vignette, "vignette");
+
+    effect.offset = photoModeOn ? 0.4 * Math.pow(1 - vignetteValue, 2) : 0;
+    effect.darkness = photoModeOn ? vignetteValue : 0;
+  }, [effect, vignette, photoModeOn]);
+
+  return null;
+}

--- a/src/hooks/usePhotoModeEffects.ts
+++ b/src/hooks/usePhotoModeEffects.ts
@@ -1,0 +1,67 @@
+/**
+ * usePhotoModeEffects Hook
+ * Provides access to photo mode effect values and control functions
+ * Only returns properties for enabled effects (others return undefined)
+ */
+
+import { usePhotoModeEffectsStore } from "../store/photoModeEffectsStore";
+import type { EffectKey } from "../types";
+
+/**
+ * Return type for usePhotoModeEffects
+ * All effect values may be undefined if not enabled in ENABLED_EFFECTS config
+ */
+export type UsePhotoModeEffectsReturn = {
+  /** Hue adjustment value (-PI to PI) - undefined if hueSaturation disabled */
+  hue: number | undefined;
+  /** Saturation adjustment value (-1 to 1) - undefined if hueSaturation disabled */
+  saturation: number | undefined;
+  /** Brightness adjustment value (-0.75 to 0.75) - undefined if brightnessContrast disabled */
+  brightness: number | undefined;
+  /** Contrast adjustment value (-0.75 to 0.75) - undefined if brightnessContrast disabled */
+  contrast: number | undefined;
+  /** Chromatic aberration offset (0 to 0.01) - undefined if chromaticAberration disabled */
+  chromaticAberration: number | undefined;
+  /** Bloom intensity (0 to 5) - undefined if bloom disabled */
+  bloom: number | undefined;
+  /** Vignette darkness (0 to 1) - undefined if vignette disabled */
+  vignette: number | undefined;
+  /** Film grain amount (0 to 1) - undefined if grain disabled */
+  grain: number | undefined;
+  /** Update effect value by key */
+  setEffect: (effectName: EffectKey, value: number) => void;
+  /** Reset all effects to default values */
+  resetEffects: () => void;
+};
+
+/**
+ * Hook to access and control photo mode effects
+ * @returns Object with effect values and control functions
+ */
+export function usePhotoModeEffects(): UsePhotoModeEffectsReturn {
+  const hue = usePhotoModeEffectsStore((state) => state.hue);
+  const saturation = usePhotoModeEffectsStore((state) => state.saturation);
+  const brightness = usePhotoModeEffectsStore((state) => state.brightness);
+  const contrast = usePhotoModeEffectsStore((state) => state.contrast);
+  const chromaticAberration = usePhotoModeEffectsStore((state) => state.chromaticAberration);
+  const bloom = usePhotoModeEffectsStore((state) => state.bloom);
+  const vignette = usePhotoModeEffectsStore((state) => state.vignette);
+  const grain = usePhotoModeEffectsStore((state) => state.grain);
+
+  const enabledEffects = usePhotoModeEffectsStore((state) => state.enabledEffects);
+  const setEffect = usePhotoModeEffectsStore((state) => state.setEffect);
+  const resetEffects = usePhotoModeEffectsStore((state) => state.resetEffects);
+
+  return {
+    hue: enabledEffects.hueSaturation ? hue : undefined,
+    saturation: enabledEffects.hueSaturation ? saturation : undefined,
+    brightness: enabledEffects.brightnessContrast ? brightness : undefined,
+    contrast: enabledEffects.brightnessContrast ? contrast : undefined,
+    chromaticAberration: enabledEffects.chromaticAberration ? chromaticAberration : undefined,
+    bloom: enabledEffects.bloom ? bloom : undefined,
+    vignette: enabledEffects.vignette ? vignette : undefined,
+    grain: enabledEffects.grain ? grain : undefined,
+    setEffect: setEffect as UsePhotoModeEffectsReturn["setEffect"],
+    resetEffects,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,6 @@
  */
 
 export { PhotoMode } from "./engine/PhotoMode";
-export { PhotoModeComposer } from "./engine/PhotoModeComposer";
 export { usePhotoMode } from "./hooks/usePhotoMode";
+export { usePhotoModeEffects } from "./hooks/usePhotoModeEffects";
 export * from "./types";

--- a/src/store/photoModeEffectsStore.ts
+++ b/src/store/photoModeEffectsStore.ts
@@ -1,0 +1,78 @@
+/**
+ * PhotoModeEffects store
+ * Manages all post-processing effect settings for PhotoMode
+ */
+
+import { createWithEqualityFn } from "zustand/traditional";
+import { EffectKey, EffectName } from "../types";
+import { EFFECT_DEFINITIONS, ENABLED_EFFECTS } from "../utils/constants";
+
+export type PhotoModeEffectsStore = {
+  // Individual effect settings
+  hue: number;
+  saturation: number;
+  brightness: number;
+  contrast: number;
+  chromaticAberration: number;
+  bloom: number;
+  vignette: number;
+  grain: number;
+
+  enabledEffects: Record<EffectName, boolean>;
+
+  setEnabledEffects: (effects: Record<EffectName, boolean>) => void;
+
+  // Method to update effect settings
+  setEffect: (effectName: EffectKey, value: number) => void;
+
+  // Method to reset all effects to default values
+  resetEffects: () => void;
+};
+
+// Equality check to prevent unnecessary re-renders
+const equalityFn = <T>(a: T, b: T) => a === b;
+
+// Throttle updates to max 60fps
+let lastSetTime: number = 0;
+
+export const usePhotoModeEffectsStore = createWithEqualityFn<PhotoModeEffectsStore>(
+  (set, get) => ({
+    hue: 0, // -PI to PI
+    saturation: 0, // -PI to PI
+    brightness: 0, // -1 to 1
+    contrast: 0, // -1 to 1
+    chromaticAberration: 0, // 0 to 1
+    bloom: 0, // 0 to 1
+    vignette: 0, // 0 to 1
+    grain: 0, // 0 to 1
+
+    enabledEffects: {
+      hueSaturation: ENABLED_EFFECTS.hueSaturation,
+      brightnessContrast: ENABLED_EFFECTS.brightnessContrast,
+      chromaticAberration: ENABLED_EFFECTS.chromaticAberration,
+      bloom: ENABLED_EFFECTS.bloom,
+      vignette: ENABLED_EFFECTS.vignette,
+      grain: ENABLED_EFFECTS.grain,
+    },
+
+    setEnabledEffects: (effects) => set({ enabledEffects: effects }),
+
+    setEffect: (effectName, value) => {
+      const now = performance.now();
+      if (now - lastSetTime < 16) return; // max 60fps update
+      lastSetTime = now;
+
+      const def = EFFECT_DEFINITIONS[effectName];
+      const clamped = Math.min(def.max, Math.max(def.min, value));
+      set({ [effectName]: clamped });
+    },
+
+    resetEffects: () =>
+      set(
+        Object.fromEntries(
+          Object.entries(EFFECT_DEFINITIONS).map(([key, def]) => [key, def.default]),
+        ) as Partial<PhotoModeEffectsStore>,
+      ),
+  }),
+  equalityFn,
+);

--- a/src/store/photoModeStore.ts
+++ b/src/store/photoModeStore.ts
@@ -4,46 +4,43 @@
  * Manages rendering context, composition, and screenshot functionality
  */
 
-import { EffectComposer as EffectComposerImpl } from 'postprocessing';
-import { Camera, Scene, Vector3, WebGLRenderer } from 'three';
-import { createWithEqualityFn } from 'zustand/traditional';
-import { ScreenshotOptions } from '../types';
+import { EffectComposer as EffectComposerImpl } from "postprocessing";
+import { Camera, Scene, WebGLRenderer } from "three";
+import { createWithEqualityFn } from "zustand/traditional";
+import { ScreenshotOptions } from "../types";
 
 /**
  * Internal state of PhotoMode store
  */
 type PhotoModeInternalStore = {
-	/** WebGL Renderer instance */
-	renderer?: WebGLRenderer;
-	/** Three.js Scene */
-	scene?: Scene;
-	/** Three.js Camera */
-	camera?: Camera;
-	/** EffectComposer for post-processing (optional) */
-	composer?: EffectComposerImpl | null;
+  /** Photo mode active state */
+  photoModeOn: boolean;
 
-	/** Screenshot capture function */
-	takeScreenshot?: (options?: ScreenshotOptions) => Promise<string | File>;
+  /** WebGL Renderer instance */
+  renderer?: WebGLRenderer;
+  /** Three.js Scene */
+  scene?: Scene;
+  /** Three.js Camera */
+  camera?: Camera;
+  /** EffectComposer for post-processing (optional) */
+  composer?: EffectComposerImpl | null;
 
-	/** Photo mode active state */
-	photoModeOn: boolean;
-	/** Toggle photo mode state */
-	togglePhotoMode: (value?: boolean) => void;
+  /** Screenshot capture function */
+  takeScreenshot?: (options?: ScreenshotOptions) => Promise<string | File>;
+  /** Toggle photo mode state */
+  togglePhotoMode: (value?: boolean) => void;
 
-	/** Focus target for camera (not implemented yet) */
-	focusTarget: Vector3 | null;
-
-	// Setter functions
-	/** Register WebGL renderer */
-	setRenderer: (r: WebGLRenderer) => void;
-	/** Register Scene */
-	setScene: (s: Scene) => void;
-	/** Register Camera */
-	setCamera: (c: Camera) => void;
-	/** Register EffectComposer */
-	setComposer: (c: EffectComposerImpl | null) => void;
-	/** Register screenshot function */
-	setTakeScreenshot: (fn: (options?: ScreenshotOptions) => Promise<string | File>) => void;
+  // Setter functions
+  /** Register WebGL renderer */
+  setRenderer: (r: WebGLRenderer) => void;
+  /** Register Scene */
+  setScene: (s: Scene) => void;
+  /** Register Camera */
+  setCamera: (c: Camera) => void;
+  /** Register EffectComposer */
+  setComposer: (c: EffectComposerImpl | null) => void;
+  /** Register screenshot function */
+  setTakeScreenshot: (fn: (options?: ScreenshotOptions) => Promise<string | File>) => void;
 };
 
 // Equality check to prevent unnecessary re-renders
@@ -54,33 +51,33 @@ const equalityFn = <T>(a: T, b: T) => a === b;
  * Manages all state required for screenshot capture
  */
 export const usePhotoModeStore = createWithEqualityFn<PhotoModeInternalStore>(
-	(set) => ({
-		renderer: undefined,
-		scene: undefined,
-		camera: undefined,
-		composer: undefined,
-		takeScreenshot: undefined,
+  (set) => ({
+    photoModeOn: true,
 
-		photoModeOn: false,
-		focusTarget: null,
-		/**
-		 * Toggle photo mode state
-		 * @param value - Explicit boolean or undefined to toggle
-		 */
-		togglePhotoMode: (value) =>
-			set((state) => {
-				if (value !== undefined) {
-					return { photoModeOn: value };
-				} else {
-					return { photoModeOn: !state.photoModeOn };
-				}
-			}),
+    renderer: undefined,
+    scene: undefined,
+    camera: undefined,
+    composer: undefined,
+    takeScreenshot: undefined,
 
-		setRenderer: (r) => set({ renderer: r }),
-		setScene: (s) => set({ scene: s }),
-		setCamera: (c) => set({ camera: c }),
-		setComposer: (c) => set({ composer: c }),
-		setTakeScreenshot: (fn) => set({ takeScreenshot: fn }),
-	}),
-	equalityFn,
+    /**
+     * Toggle photo mode state
+     * @param value - Explicit boolean or undefined to toggle
+     */
+    togglePhotoMode: (value) =>
+      set((state) => {
+        if (value !== undefined) {
+          return { photoModeOn: value };
+        } else {
+          return { photoModeOn: !state.photoModeOn };
+        }
+      }),
+
+    setRenderer: (r) => set({ renderer: r }),
+    setScene: (s) => set({ scene: s }),
+    setCamera: (c) => set({ camera: c }),
+    setComposer: (c) => set({ composer: c }),
+    setTakeScreenshot: (fn) => set({ takeScreenshot: fn }),
+  }),
+  equalityFn,
 );

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,21 +1,21 @@
-import { Camera } from '@react-three/fiber';
-import { EffectComposer } from 'postprocessing';
-import { Scene, WebGLRenderer } from 'three';
+import { Camera } from "@react-three/fiber";
+import { EffectComposer } from "postprocessing";
+import { Scene, WebGLRenderer } from "three";
 
 /**
  * Configuration options for screenshot capture
  */
 export type ScreenshotOptions = {
-	/** Target image width in pixels */
-	width?: number;
-	/** Target image height in pixels */
-	height?: number;
-	/** Image format (JPEG, PNG, WebP, AVIF) */
-	format?: 'jpeg' | 'png' | 'webp' | 'avif';
-	/** Compression quality (0-1) */
-	quality?: number;
-	/** Return as File instead of DataURL */
-	toFile?: boolean;
+  /** Target image width in pixels */
+  width?: number;
+  /** Target image height in pixels */
+  height?: number;
+  /** Image format (JPEG, PNG, WebP, AVIF) */
+  format?: "jpeg" | "png" | "webp" | "avif";
+  /** Compression quality (0-1) */
+  quality?: number;
+  /** Return as File instead of DataURL */
+  toFile?: boolean;
 };
 
 /**
@@ -23,4 +23,39 @@ export type ScreenshotOptions = {
  * Takes Three.js rendering context and returns a function that captures screenshots
  * WebGLRenderTarget is created and disposed internally per screenshot
  */
-export type TakeScreenshotFn = (gl: WebGLRenderer, scene: Scene, camera: Camera, composer?: EffectComposer) => (options?: ScreenshotOptions) => Promise<string | File>;
+export type TakeScreenshotFn = (
+  gl: WebGLRenderer,
+  scene: Scene,
+  camera: Camera,
+  composer?: EffectComposer,
+) => (options?: ScreenshotOptions) => Promise<string | File>;
+
+/**
+ * PhotoModeComposer effects settings
+ */
+export type EffectKey =
+  | "brightness"
+  | "contrast"
+  | "hue"
+  | "saturation"
+  | "vignette"
+  | "chromaticAberration"
+  | "bloom"
+  | "grain";
+
+export type EffectName =
+  | "brightnessContrast"
+  | "hueSaturation"
+  | "vignette"
+  | "chromaticAberration"
+  | "bloom"
+  | "grain";
+
+export type EffectDefinition = {
+  label: string;
+  min: number;
+  max: number;
+  default: number;
+  effectMin?: number;
+  effectMax?: number;
+};

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,71 @@
+import { EffectDefinition, EffectKey, EffectName } from "../types";
+
+export const EFFECT_DEFINITIONS: Record<EffectKey, EffectDefinition> = {
+  brightness: {
+    label: "Brightness",
+    min: -1,
+    max: 1,
+    default: 0,
+    effectMin: -0.75,
+    effectMax: 0.75,
+  },
+  contrast: {
+    label: "Contrast",
+    min: -1,
+    max: 1,
+    default: 0,
+    effectMin: -0.75,
+    effectMax: 0.75,
+  },
+  hue: {
+    label: "Hue",
+    min: -1,
+    max: 1,
+    default: 0,
+    effectMin: -Math.PI,
+    effectMax: Math.PI,
+  },
+  saturation: {
+    label: "Saturation",
+    min: -1,
+    max: 1,
+    default: 0,
+  },
+  vignette: {
+    label: "Vignette",
+    min: 0,
+    max: 1,
+    default: 0,
+  },
+  chromaticAberration: {
+    label: "Chromatic Aberration",
+    min: 0,
+    max: 1,
+    default: 0,
+    effectMin: 0,
+    effectMax: 0.01,
+  },
+  bloom: {
+    label: "Bloom",
+    min: 0,
+    max: 1,
+    default: 0,
+    effectMin: 0,
+    effectMax: 5,
+  },
+  grain: {
+    label: "Grain",
+    min: 0,
+    max: 1,
+    default: 0,
+  },
+};
+
+export const ENABLED_EFFECTS: Record<EffectName, boolean> = {
+  brightnessContrast: true,
+  hueSaturation: true,
+  vignette: true,
+  chromaticAberration: true,
+  bloom: false,
+  grain: true,
+};

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -1,142 +1,165 @@
-import { EffectComposer as EffectComposerImpl } from 'postprocessing';
-import { PerspectiveCamera, RGBAFormat, Scene, Texture, UnsignedByteType, Vector2, WebGLRenderer, WebGLRenderTarget } from 'three';
-import { TakeScreenshotFn } from '../types';
-import { CapturePass } from './CapturePass';
+import { EffectComposer as EffectComposerImpl } from "postprocessing";
+import {
+  PerspectiveCamera,
+  RGBAFormat,
+  Scene,
+  Texture,
+  UnsignedByteType,
+  Vector2,
+  WebGLRenderer,
+  WebGLRenderTarget,
+} from "three";
+import { EffectKey, TakeScreenshotFn } from "../types";
+import { CapturePass } from "./CapturePass";
+import { EFFECT_DEFINITIONS } from "./constants";
 
 /**
  * Flips pixel buffer vertically (Y-axis)
  */
 const flipY = (buffer: Uint8Array, width: number, height: number) => {
-	const rowSize = width * 4;
-	const temp = new Uint8Array(rowSize);
+  const rowSize = width * 4;
+  const temp = new Uint8Array(rowSize);
 
-	for (let y = 0; y < height / 2; y++) {
-		const top = y * rowSize;
-		const bottom = (height - y - 1) * rowSize;
+  for (let y = 0; y < height / 2; y++) {
+    const top = y * rowSize;
+    const bottom = (height - y - 1) * rowSize;
 
-		temp.set(buffer.subarray(top, top + rowSize));
-		buffer.copyWithin(top, bottom, bottom + rowSize);
-		buffer.set(temp, bottom);
-	}
+    temp.set(buffer.subarray(top, top + rowSize));
+    buffer.copyWithin(top, bottom, bottom + rowSize);
+    buffer.set(temp, bottom);
+  }
 };
 
 /**
  * Creates a WebGL render target for screenshot capture
  */
 const createRenderTarget = (gl: WebGLRenderer, width: number, height: number): WebGLRenderTarget<Texture> => {
-	const target = new WebGLRenderTarget(width, height, {
-		format: RGBAFormat,
-		type: UnsignedByteType,
-		colorSpace: gl.outputColorSpace as any,
-		samples: 4,
-		depthBuffer: true,
-	});
-	return target;
+  const target = new WebGLRenderTarget(width, height, {
+    format: RGBAFormat,
+    type: UnsignedByteType,
+    colorSpace: gl.outputColorSpace as any,
+    samples: 4,
+    depthBuffer: true,
+  });
+  return target;
 };
 
 /**
  * Stores the current renderer and camera state
  */
 type RenderState = {
-	prevTarget: WebGLRenderTarget<Texture> | null;
-	prevSize: Vector2;
-	prevPixelRatio: number;
-	prevAspect: number;
+  prevTarget: WebGLRenderTarget<Texture> | null;
+  prevSize: Vector2;
+  prevPixelRatio: number;
+  prevAspect: number;
 };
 
 /**
  * Saves current renderer and camera state for restoration
  */
 const saveRenderState = (gl: WebGLRenderer, camera: PerspectiveCamera): RenderState => ({
-	prevTarget: gl.getRenderTarget(),
-	prevSize: gl.getSize(new Vector2()),
-	prevPixelRatio: gl.getPixelRatio(),
-	prevAspect: camera.aspect,
+  prevTarget: gl.getRenderTarget(),
+  prevSize: gl.getSize(new Vector2()),
+  prevPixelRatio: gl.getPixelRatio(),
+  prevAspect: camera.aspect,
 });
 
 /**
  * Configures camera aspect ratio for screenshot
  */
 const configureCamera = (camera: PerspectiveCamera, width: number, height: number) => {
-	camera.aspect = width / height;
-	camera.updateProjectionMatrix();
+  camera.aspect = width / height;
+  camera.updateProjectionMatrix();
 };
 
 /**
  * Renders scene to FBO with or without post-processing
  */
-const renderToFBO = (gl: WebGLRenderer, scene: Scene, camera: PerspectiveCamera, fbo: WebGLRenderTarget<Texture>, composer?: EffectComposerImpl | null) => {
-	if (composer) {
-		// Use EffectComposer to render with post-processing
-		const prevRenderToScreen = composer.passes?.map((p: any) => p?.renderToScreen);
-		const prevComposerSize = new Vector2(composer.outputBuffer.width, composer.outputBuffer.height);
+const renderToFBO = (
+  gl: WebGLRenderer,
+  scene: Scene,
+  camera: PerspectiveCamera,
+  fbo: WebGLRenderTarget<Texture>,
+  composer?: EffectComposerImpl | null,
+) => {
+  if (composer) {
+    // Use EffectComposer to render with post-processing
+    const prevRenderToScreen = composer.passes?.map((p: any) => p?.renderToScreen);
+    const prevComposerSize = new Vector2(composer.outputBuffer.width, composer.outputBuffer.height);
 
-		const capturePass = new CapturePass(fbo);
+    const capturePass = new CapturePass(fbo);
 
-		try {
-			composer.setSize(fbo.width, fbo.height, false);
-			composer.addPass(capturePass);
+    try {
+      composer.setSize(fbo.width, fbo.height, false);
+      composer.addPass(capturePass);
 
-			composer.passes.forEach((pass) => {
-				if (pass) pass.renderToScreen = false;
-			});
+      composer.passes.forEach((pass) => {
+        if (pass) pass.renderToScreen = false;
+      });
 
-			composer.render();
-		} finally {
-			composer.removePass(capturePass);
+      composer.render();
+    } finally {
+      composer.removePass(capturePass);
 
-			if (prevRenderToScreen) {
-				for (let i = 0; i < composer.passes.length; i++) {
-					const p = composer.passes[i];
-					if (p && typeof prevRenderToScreen[i] !== 'undefined') {
-						p.renderToScreen = prevRenderToScreen[i];
-					}
-				}
-			}
+      if (prevRenderToScreen) {
+        for (let i = 0; i < composer.passes.length; i++) {
+          const p = composer.passes[i];
+          if (p && typeof prevRenderToScreen[i] !== "undefined") {
+            p.renderToScreen = prevRenderToScreen[i];
+          }
+        }
+      }
 
-			composer.setSize(prevComposerSize.x, prevComposerSize.y, false);
-		}
-	} else {
-		// Direct rendering without post-processing
-		gl.setRenderTarget(fbo);
-		gl.render(scene, camera);
-	}
+      composer.setSize(prevComposerSize.x, prevComposerSize.y, false);
+    }
+  } else {
+    // Direct rendering without post-processing
+    gl.setRenderTarget(fbo);
+    gl.render(scene, camera);
+  }
 };
 
 /**
  * Restores renderer and camera to previous state
  */
 const restoreRenderState = (gl: WebGLRenderer, camera: PerspectiveCamera, state: RenderState) => {
-	camera.aspect = state.prevAspect;
-	camera.updateProjectionMatrix();
-	gl.setPixelRatio(state.prevPixelRatio);
-	gl.setSize(state.prevSize.x, state.prevSize.y, false);
-	gl.setRenderTarget(state.prevTarget);
+  camera.aspect = state.prevAspect;
+  camera.updateProjectionMatrix();
+  gl.setPixelRatio(state.prevPixelRatio);
+  gl.setSize(state.prevSize.x, state.prevSize.y, false);
+  gl.setRenderTarget(state.prevTarget);
 };
 
 /**
  * Converts pixel buffer to canvas element
  */
 const pixelsToCanvas = (buffer: Uint8Array, width: number, height: number): HTMLCanvasElement => {
-	const canvas = document.createElement('canvas');
-	canvas.width = width;
-	canvas.height = height;
-	const ctx = canvas.getContext('2d')!;
-	ctx.putImageData(new ImageData(new Uint8ClampedArray(buffer), width, height), 0, 0);
-	return canvas;
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext("2d")!;
+  ctx.putImageData(new ImageData(new Uint8ClampedArray(buffer), width, height), 0, 0);
+  return canvas;
 };
 
 /**
  * Converts canvas to File or DataURL string
  */
-const canvasToOutput = async (canvas: HTMLCanvasElement, format: string, quality: number, toFile?: boolean): Promise<string | File> => {
-	const blob = await new Promise<Blob>((resolve, reject) => canvas.toBlob((b) => (b ? resolve(b) : reject(new Error('toBlob failed'))), `image/${format}`, quality));
+const canvasToOutput = async (
+  canvas: HTMLCanvasElement,
+  format: string,
+  quality: number,
+  toFile?: boolean,
+): Promise<string | File> => {
+  const blob = await new Promise<Blob>((resolve, reject) =>
+    canvas.toBlob((b) => (b ? resolve(b) : reject(new Error("toBlob failed"))), `image/${format}`, quality),
+  );
 
-	if (toFile) {
-		return new File([blob], `screenshot.${format}`, { type: `image/${format}` });
-	} else {
-		return URL.createObjectURL(blob);
-	}
+  if (toFile) {
+    return new File([blob], `screenshot.${format}`, { type: `image/${format}` });
+  } else {
+    return URL.createObjectURL(blob);
+  }
 };
 
 /**
@@ -145,53 +168,87 @@ const canvasToOutput = async (canvas: HTMLCanvasElement, format: string, quality
  * Creates and disposes WebGLRenderTarget internally
  */
 export const takeScreenshot: TakeScreenshotFn = (gl, scene, camera, composer) => async (options?) => {
-	// Save current state
-	const renderState = saveRenderState(gl, camera as PerspectiveCamera);
+  // Save current state
+  const renderState = saveRenderState(gl, camera as PerspectiveCamera);
 
-	// Determine screenshot parameters
-	const width = options?.width ?? renderState.prevSize.x;
-	const height = options?.height ?? renderState.prevSize.y;
-	const format = options?.format ?? 'jpeg';
-	const quality = options?.quality ?? 1;
+  // Determine screenshot parameters
+  const width = options?.width ?? renderState.prevSize.x;
+  const height = options?.height ?? renderState.prevSize.y;
+  const format = options?.format ?? "jpeg";
+  const quality = options?.quality ?? 1;
 
-	try {
-		// Ensure pixel ratio is 1 for consistent results
-		gl.setPixelRatio(1);
-		gl.setSize(width, height, false);
+  try {
+    // Ensure pixel ratio is 1 for consistent results
+    gl.setPixelRatio(1);
+    gl.setSize(width, height, false);
 
-		const pixelSize = new Vector2();
-		gl.getDrawingBufferSize(pixelSize);
+    const pixelSize = new Vector2();
+    gl.getDrawingBufferSize(pixelSize);
 
-		// Output dimensions
-		const outputWidth = pixelSize.x;
-		const outputHeight = pixelSize.y;
+    // Output dimensions
+    const outputWidth = pixelSize.x;
+    const outputHeight = pixelSize.y;
 
-		// Create pixel buffer
-		const buffer = new Uint8Array(outputWidth * outputHeight * 4);
+    // Create pixel buffer
+    const buffer = new Uint8Array(outputWidth * outputHeight * 4);
 
-		// Create render target for this screenshot
-		const fbo = createRenderTarget(gl, outputWidth, outputHeight);
+    // Create render target for this screenshot
+    const fbo = createRenderTarget(gl, outputWidth, outputHeight);
 
-		// Configure camera
-		configureCamera(camera as PerspectiveCamera, outputWidth, outputHeight);
+    // Configure camera
+    configureCamera(camera as PerspectiveCamera, outputWidth, outputHeight);
 
-		// Render to FBO
-		renderToFBO(gl, scene, camera as PerspectiveCamera, fbo, composer);
+    // Render to FBO
+    renderToFBO(gl, scene, camera as PerspectiveCamera, fbo, composer);
 
-		// Read pixels from FBO
-		gl.readRenderTargetPixels(fbo, 0, 0, outputWidth, outputHeight, buffer);
+    // Read pixels from FBO
+    gl.readRenderTargetPixels(fbo, 0, 0, outputWidth, outputHeight, buffer);
 
-		// Cleanup render target
-		fbo.dispose();
+    // Cleanup render target
+    fbo.dispose();
 
-		// Flip Y-axis
-		flipY(buffer, outputWidth, outputHeight);
+    // Flip Y-axis
+    flipY(buffer, outputWidth, outputHeight);
 
-		// Convert to output format
-		const canvas = pixelsToCanvas(buffer, outputWidth, outputHeight);
-		return canvasToOutput(canvas, format, quality, options?.toFile);
-	} finally {
-		// Restore previous state
-		restoreRenderState(gl, camera as PerspectiveCamera, renderState);
-	}
+    // Convert to output format
+    const canvas = pixelsToCanvas(buffer, outputWidth, outputHeight);
+    return canvasToOutput(canvas, format, quality, options?.toFile);
+  } finally {
+    // Restore previous state
+    restoreRenderState(gl, camera as PerspectiveCamera, renderState);
+  }
 };
+
+/**
+ * Map effect value from UI range to actual effect range
+ * @param normalizedValue - Value in UI range (typically -100 to 100 or 0 to 100)
+ * @param effectKey - Effect key to determine target range
+ * @returns Mapped value in target range (effectMin-effectMax if defined, otherwise min-max), rounded to 3 decimal places
+ *
+ * @example
+ * // Maps using effectMin/effectMax if available
+ * mapEffectValue(50, "brightness") // Maps 50 from UI range to actual effect range
+ *
+ * // Falls back to min/max if effectMin/effectMax not defined
+ * mapEffectValue(100, "vignette") // Uses min-max range
+ */
+export function mapEffectValue(normalizedValue: number, effectKey: EffectKey): number {
+  const effectDefinition = EFFECT_DEFINITIONS[effectKey];
+
+  // Determine the UI range (min/max from definition)
+  const uiMin = effectDefinition.min;
+  const uiMax = effectDefinition.max;
+
+  // Clamp value to UI range
+  const clamped = Math.max(uiMin, Math.min(uiMax, normalizedValue));
+
+  // Determine target range: use effectMin/effectMax if available, otherwise min/max
+  const targetMin = effectDefinition.effectMin ?? effectDefinition.min;
+  const targetMax = effectDefinition.effectMax ?? effectDefinition.max;
+
+  // Map from UI range to target range
+  const mapped = ((clamped - uiMin) / (uiMax - uiMin)) * (targetMax - targetMin) + targetMin;
+
+  // Round to 3 decimal places
+  return Math.round(mapped * 1000) / 1000;
+}


### PR DESCRIPTION
- Move EffectComposer into PhotoMode component
- Add usePhotoModeEffects hook for effect control
- Support Bloom, Brightness/Contrast, Hue/Saturation, Vignette, Chromatic Aberration and Grain effects
- Update README with new API documentation
- Increment version to 0.2.0